### PR TITLE
Add ergonomic LLM runner and grep-based context tools

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,95 @@
+"""Minimal LLM runner with logging and optional grep context."""
+from __future__ import annotations
+
+import argparse
+import os
+
+from tools.llm_client import LLM
+from tools.context_tools import grep_context
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Minimal LLM runner with logging + optional grep context")
+    # model & sampling
+    p.add_argument("--model", default=os.getenv("OPENAI_MODEL", "gpt-4o"),
+                   help="Model id (or set OPENAI_MODEL)")
+    p.add_argument("--temperature", type=float, default=float(os.getenv("OPENAI_TEMPERATURE", 0.2)))
+    p.add_argument("--top-p", dest="top_p", type=float, default=float(os.getenv("OPENAI_TOP_P", 1.0)))
+    p.add_argument("--max-output-tokens", dest="max_output_tokens", type=int,
+                   default=int(os.getenv("OPENAI_MAX_OUTPUT_TOKENS", "1024")))
+    p.add_argument("--seed", type=int, default=os.getenv("OPENAI_SEED") and int(os.getenv("OPENAI_SEED")),
+                   help="Set for deterministic-ish outputs")
+
+    # output shaping
+    p.add_argument("--json", action="store_true",
+                   help="Force JSON responses with response_format=json_object")
+
+    # logging/meta
+    p.add_argument("--session", default=os.getenv("LLM_SESSION", "default"))
+    p.add_argument("--tags", default=os.getenv("LLM_TAGS", ""),
+                   help="Comma-separated tags for the log record")
+
+    # optional grep context
+    p.add_argument("--grep", nargs="+", metavar="PATH_OR_GLOB",
+                   help="Paths or globs to search for context")
+    p.add_argument("--regex", help="Regex pattern to match")
+    p.add_argument("--keywords", nargs="+", help="Simple substring keywords (OR logic)")
+    p.add_argument("--include", action="append", default=[],
+                   help="Include glob (repeatable). Example: --include '**/*.py'")
+    p.add_argument("--exclude", action="append", default=[],
+                   help="Exclude glob (repeatable). Example: --exclude 'node_modules/**'")
+    p.add_argument("--context-lines", type=int, default=2, help="Lines of context before/after each match")
+    p.add_argument("--max-context-tokens", type=int, default=1500,
+                   help="Budget for context snippets (approx)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    response_format = {"type": "json_object"} if args.json else None
+
+    llm = LLM(
+        model=args.model,
+        instructions=os.getenv("OPENAI_INSTRUCTIONS", "You are an open-source AI that respects privacy."),
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_output_tokens=args.max_output_tokens,
+        seed=args.seed,
+        response_format=response_format,
+    )
+
+    ctx = None
+    if args.grep and (args.regex or args.keywords):
+        ctx_text, stats = grep_context(
+            paths=args.grep,
+            regex=args.regex,
+            keywords=args.keywords,
+            include=args.include,
+            exclude=args.exclude,
+            before=args.context_lines,
+            after=args.context_lines,
+            max_tokens=args.max_context_tokens,
+        )
+        if ctx_text.strip():
+            print(f"[context] using {stats['snippets']} snippets from {stats['files']} files (~{stats['tokens']} toks est.)")
+            ctx = ctx_text
+
+    prompt = input("llm input:\n===\n")
+    print("===\n\nllm output:\n===\n")
+
+    resp = llm.pred(
+        prompt,
+        session=args.session,
+        tags=[t.strip() for t in args.tags.split(",") if t.strip()],
+        context=ctx,
+        context_title="Grep Context",
+    )
+    try:
+        print(resp.output_text)
+    except Exception:
+        print(resp)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for lightweight LLM tooling."""

--- a/tools/context_tools.py
+++ b/tools/context_tools.py
@@ -1,0 +1,112 @@
+"""Utilities for gathering textual context via simple grep-like searches."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
+
+import fnmatch
+
+
+def _iter_files(paths: Sequence[str], include: Sequence[str], exclude: Sequence[str]) -> Iterable[Path]:
+    seen: Set[Path] = set()
+    for p in paths:
+        for path in Path().glob(p):
+            if path.is_dir():
+                for file in path.rglob("*"):
+                    if file.is_file():
+                        if _match_globs(file, include, exclude):
+                            if file not in seen:
+                                seen.add(file)
+                                yield file
+            elif path.is_file():
+                if _match_globs(path, include, exclude):
+                    if path not in seen:
+                        seen.add(path)
+                        yield path
+
+
+def _match_globs(path: Path, include: Sequence[str], exclude: Sequence[str]) -> bool:
+    as_posix = path.as_posix()
+    if include:
+        if not any(fnmatch.fnmatch(as_posix, pat) for pat in include):
+            return False
+    if any(fnmatch.fnmatch(as_posix, pat) for pat in exclude):
+        return False
+    return True
+
+
+def _estimate_tokens(text: str) -> int:
+    # naive token estimate
+    return max(1, len(text.split()))
+
+
+def grep_context(*, paths: Sequence[str], regex: Optional[str] = None, keywords: Optional[Sequence[str]] = None,
+                 include: Sequence[str] = (), exclude: Sequence[str] = (), before: int = 2, after: int = 2,
+                 case_sensitive: bool = False, max_tokens: int = 1500) -> Tuple[str, dict]:
+    """Search paths for regex/keywords and return snippets within token budget."""
+    flags = 0 if case_sensitive else re.IGNORECASE
+    pattern = re.compile(regex, flags) if regex else None
+    kw_lower = [k if case_sensitive else k.lower() for k in (keywords or [])]
+
+    snippets: List[str] = []
+    files_seen: Set[str] = set()
+    token_count = 0
+
+    for file in _iter_files(paths, include, exclude):
+        try:
+            text = file.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        lines = text.splitlines()
+        matches_here = 0
+        for idx, line in enumerate(lines):
+            hay = line if case_sensitive else line.lower()
+            matched = False
+            if pattern and pattern.search(line):
+                matched = True
+            if kw_lower and any(k in hay for k in kw_lower):
+                matched = True
+            if not matched:
+                continue
+            start = max(0, idx - before)
+            end = min(len(lines), idx + after + 1)
+            snippet = "\n".join(lines[start:end])
+            header = f"=== {file}:{idx+1} ==="
+            block = f"{header}\n{snippet}\n"
+            cost = _estimate_tokens(block)
+            if token_count + cost > max_tokens:
+                continue
+            snippets.append(block)
+            token_count += cost
+            matches_here += 1
+            files_seen.add(str(file))
+            if matches_here > 0 and token_count >= max_tokens:
+                break
+
+    if not snippets:
+        return "", {"files": 0, "snippets": 0, "tokens": 0}
+    context_text = "\n".join(snippets)
+    return context_text, {"files": len(files_seen), "snippets": len(snippets), "tokens": token_count}
+
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--paths", nargs="+", required=True)
+    ap.add_argument("--regex")
+    ap.add_argument("--keywords", nargs="+")
+    ap.add_argument("--include", action="append", default=[])
+    ap.add_argument("--exclude", action="append", default=[])
+    ap.add_argument("--before", type=int, default=2)
+    ap.add_argument("--after", type=int, default=2)
+    ap.add_argument("--case-sensitive", action="store_true")
+    ap.add_argument("--max-tokens", type=int, default=1500)
+    args = ap.parse_args()
+    ctx, stats = grep_context(paths=args.paths, regex=args.regex, keywords=args.keywords,
+                               include=args.include, exclude=args.exclude, before=args.before,
+                               after=args.after, case_sensitive=args.case_sensitive,
+                               max_tokens=args.max_tokens)
+    print(ctx)
+    print("\n---")
+    print(stats)

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -1,0 +1,61 @@
+"""Wrapper around the OpenAI Responses API with simple logging."""
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from .log_utils import JsonlLogger, make_record
+
+
+class LLM:
+    """Lightweight convenience wrapper for OpenAI's client."""
+
+    def __init__(self, *, model: str, instructions: str, temperature: float = 0.0,
+                 top_p: float = 1.0, max_output_tokens: int = 1024,
+                 seed: Optional[int] = None, response_format: Optional[dict] = None) -> None:
+        load_dotenv()
+        self.client = OpenAI()
+        self.model = model
+        self.instructions = instructions
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_output_tokens = max_output_tokens
+        self.seed = seed
+        self.response_format = response_format
+        self.logger = JsonlLogger()
+
+    def pred(self, prompt: str, *, session: str = "default", tags: Optional[List[str]] = None,
+             context: Optional[str] = None, context_title: str = "Context"):
+        """Send prompt (optionally with context) and log the response."""
+        if context:
+            user_content = f"{context_title}:\n{context}\n\n{prompt}"
+        else:
+            user_content = prompt
+
+        messages = [
+            {"role": "system", "content": self.instructions},
+            {"role": "user", "content": user_content},
+        ]
+
+        resp = self.client.responses.create(
+            model=self.model,
+            input=messages,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            max_output_tokens=self.max_output_tokens,
+            seed=self.seed,
+            response_format=self.response_format,
+        )
+
+        try:
+            output_text = resp.output_text  # type: ignore[attr-defined]
+        except Exception:
+            output_text = str(resp)
+
+        record = make_record(prompt, output_text, model=self.model, session=session,
+                              tags=tags, context=context)
+        self.logger.log(record)
+        return resp

--- a/tools/log_utils.py
+++ b/tools/log_utils.py
@@ -1,0 +1,56 @@
+"""Minimal JSONL logging helpers."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _ensure_parent(path: Path) -> None:
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class LogRecord:
+    """Structure for a single LLM interaction."""
+
+    timestamp: float
+    session: str
+    model: str
+    prompt: str
+    response: str
+    tags: List[str]
+    context: Optional[str] = None
+
+
+def make_record(prompt: str, response: str, *, model: str, session: str,
+                tags: Optional[List[str]] = None, context: Optional[str] = None) -> LogRecord:
+    """Create a :class:`LogRecord` from interaction pieces."""
+    return LogRecord(
+        timestamp=time.time(),
+        session=session,
+        model=model,
+        prompt=prompt,
+        response=response,
+        tags=tags or [],
+        context=context,
+    )
+
+
+class JsonlLogger:
+    """Append log records to a JSONL file if configured."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = Path(path or os.getenv("LLM_LOG_FILE", ""))
+
+    def log(self, record: LogRecord) -> None:
+        if not self.path:
+            return
+        _ensure_parent(self.path)
+        with self.path.open("a", encoding="utf-8") as fh:
+            json.dump(asdict(record), fh)
+            fh.write("\n")


### PR DESCRIPTION
## Summary
- add `main.py` exposing CLI params for model, sampling, logging and grep context
- implement `LLM` client wrapper with JSONL logging
- provide `grep_context` utility and minimal logging helpers

## Testing
- `python -m py_compile main.py tools/*.py`
- `python main.py --help`
- `python -m tools.context_tools --paths tools --keywords LLM --include '**/*.py'`


------
https://chatgpt.com/codex/tasks/task_e_689819410c348322a5487af7d2b2df44