### PR TITLE
Add minimal CLI and tools for LLM interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/main.py
+++ b/main.py
@@ -1,0 +1,88 @@
+import os
+import argparse
+from tools.llm_client import LLM
+from tools.context_tools import grep_context
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Minimal LLM runner with logging + optional grep context")
+    # model & sampling
+    p.add_argument("--model", default=os.getenv("OPENAI_MODEL", "gpt-4o"),
+                   help="Model id (or set OPENAI_MODEL)")
+    p.add_argument("--temperature", type=float, default=float(os.getenv("OPENAI_TEMPERATURE", 0.2)))
+    p.add_argument("--top-p", dest="top_p", type=float, default=float(os.getenv("OPENAI_TOP_P", 1.0)))
+    p.add_argument("--max-output-tokens", dest="max_output_tokens", type=int,
+                   default=int(os.getenv("OPENAI_MAX_OUTPUT_TOKENS", "1024")))
+    p.add_argument("--seed", type=int, default=os.getenv("OPENAI_SEED") and int(os.getenv("OPENAI_SEED")),
+                   help="Set for deterministic-ish outputs")
+
+    # output shaping
+    p.add_argument("--json", action="store_true",
+                   help="Force JSON responses with response_format=json_object")
+
+    # logging/meta
+    p.add_argument("--session", default=os.getenv("LLM_SESSION", "default"))
+    p.add_argument("--tags", default=os.getenv("LLM_TAGS", ""),
+                   help="Comma-separated tags for the log record")
+
+    # optional grep context
+    p.add_argument("--grep", nargs="+", metavar="PATH_OR_GLOB",
+                   help="One or more paths/globs to search for context (e.g., src/ **/*.py README.md)")
+    p.add_argument("--regex", help="Regex to match (e.g., '(LLM|ChatGPT)')")
+    p.add_argument("--keywords", nargs="+", help="Simple substring keywords (OR logic)")
+    p.add_argument("--include", action="append", default=[],
+                   help="Include glob (repeatable). Example: --include '**/*.py'")
+    p.add_argument("--exclude", action="append", default=[],
+                   help="Exclude glob (repeatable). Example: --exclude 'node_modules/**'")
+    p.add_argument("--context-lines", type=int, default=2, help="Lines of context before/after each match")
+    p.add_argument("--max-context-tokens", type=int, default=1500,
+                   help="Budget for context snippets (approx)")
+
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Build response_format only if requested
+    response_format = {"type": "json_object"} if args.json else None
+
+    llm = LLM(
+        model=args.model,
+        instructions=os.getenv("OPENAI_INSTRUCTIONS", "You are an open-source AI that respects privacy."),
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_output_tokens=args.max_output_tokens,
+        seed=args.seed,
+        response_format=response_format,
+    )
+
+    # Optional: gather grep context
+    ctx = None
+    if args.grep and (args.regex or args.keywords):
+        ctx_text, stats = grep_context(
+            paths=args.grep,
+            regex=args.regex,
+            keywords=args.keywords,
+            include=args.include,
+            exclude=args.exclude,
+            before=args.context_lines,
+            after=args.context_lines,
+            max_tokens=args.max_context_tokens,
+        )
+        if ctx_text.strip():
+            print(f"[context] using {stats['snippets']} snippets from {stats['files']} files (~{stats['tokens']} toks est.)")
+            ctx = ctx_text
+
+    # Prompt
+    prompt = input('llm input:\n===\n')
+    print('===\n\nllm output:\n===\n')
+
+    resp = llm.pred(
+        prompt,
+        session=args.session,
+        tags=[t.strip() for t in args.tags.split(',') if t.strip()],
+        context=ctx,
+        context_title="Grep Context",
+    )
+    print(resp.output_text)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# Makes tools a package so "from tools.llm_client import LLM" works

--- a/tools/context_tools.py
+++ b/tools/context_tools.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import fnmatch
+import glob
+import os
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple, Set
+
+
+def _estimate_tokens(text: str) -> int:
+    """Roughly estimate token count (4 chars ~= 1 token)."""
+    return max(1, len(text) // 4)
+
+
+def _iter_files(paths: Sequence[str], include: List[str], exclude: List[str]) -> Iterable[Path]:
+    for pattern in paths:
+        for match in glob.glob(pattern, recursive=True):
+            p = Path(match)
+            if p.is_dir():
+                candidates = p.rglob("*")
+            else:
+                candidates = [p]
+            for file in candidates:
+                if not file.is_file():
+                    continue
+                posix = file.as_posix()
+                if include and not any(fnmatch.fnmatch(posix, inc) for inc in include):
+                    continue
+                if any(fnmatch.fnmatch(posix, exc) for exc in exclude):
+                    continue
+                yield file
+
+
+def grep_context(
+    paths: Sequence[str],
+    regex: Optional[str] = None,
+    keywords: Optional[Sequence[str]] = None,
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
+    before: int = 2,
+    after: int = 2,
+    case_sensitive: bool = False,
+    max_tokens: int = 1500,
+) -> Tuple[str, dict]:
+    """Search files for regex/keywords and build context snippets.
+
+    Returns a tuple of (context_text, stats).
+    """
+
+    include = include or []
+    exclude = exclude or []
+    keywords = list(keywords or [])
+    if not case_sensitive:
+        keywords = [k.lower() for k in keywords]
+    regex_obj = re.compile(regex, 0 if case_sensitive else re.IGNORECASE) if regex else None
+
+    snippets: List[str] = []
+    token_count = 0
+    files_seen: Set[str] = set()
+    seen_spans: Set[Tuple[str, int, int]] = set()
+
+    for fpath in _iter_files(paths, include, exclude):
+        try:
+            lines = fpath.read_text(encoding="utf-8", errors="ignore").splitlines(True)
+        except Exception:
+            continue
+        matches_here = 0
+        for idx, line in enumerate(lines):
+            has_match = False
+            if regex_obj and regex_obj.search(line):
+                has_match = True
+            if keywords:
+                target = line if case_sensitive else line.lower()
+                if any(k in target for k in keywords):
+                    has_match = True
+            if not has_match:
+                continue
+
+            start = max(0, idx - before)
+            end = min(len(lines), idx + after + 1)
+            key = (str(fpath), start, end)
+            if key in seen_spans:
+                continue
+            seen_spans.add(key)
+            snippet = "".join(lines[start:end]).rstrip()
+            header = f"=== {fpath}:{idx+1} ==="
+            block = f"{header}\n{snippet}\n"
+            cost = _estimate_tokens(block)
+            if token_count + cost > max_tokens:
+                continue
+            snippets.append(block)
+            token_count += cost
+            matches_here += 1
+            files_seen.add(str(fpath))
+        if matches_here > 0 and token_count >= max_tokens:
+            break
+
+    if not snippets:
+        return "", {"files": 0, "snippets": 0, "tokens": 0}
+    context_text = "\n".join(snippets)
+    return context_text, {"files": len(files_seen), "snippets": len(snippets), "tokens": token_count}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--paths", nargs="+", required=True)
+    ap.add_argument("--regex")
+    ap.add_argument("--keywords", nargs="+")
+    ap.add_argument("--include", action="append", default=[])
+    ap.add_argument("--exclude", action="append", default=[])
+    ap.add_argument("--before", type=int, default=2)
+    ap.add_argument("--after", type=int, default=2)
+    ap.add_argument("--case-sensitive", action="store_true")
+    ap.add_argument("--max-tokens", type=int, default=1500)
+    args = ap.parse_args()
+
+    ctx, stats = grep_context(
+        paths=args.paths,
+        regex=args.regex,
+        keywords=args.keywords,
+        include=args.include,
+        exclude=args.exclude,
+        before=args.before,
+        after=args.after,
+        case_sensitive=args.case_sensitive,
+        max_tokens=args.max_tokens,
+    )
+    print(ctx)
+    print("\n---")
+    print(stats)

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import List, Optional
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - fallback if package missing
+    def load_dotenv() -> None:  # type: ignore
+        return None
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - allow running without package
+    OpenAI = None
+
+from .log_utils import JsonlLogger, make_record
+
+
+class LLM:
+    """Thin wrapper around the OpenAI Responses API with logging."""
+
+    def __init__(
+        self,
+        model: str,
+        instructions: str,
+        temperature: float = 0.2,
+        top_p: float = 1.0,
+        max_output_tokens: int = 1024,
+        seed: Optional[int] = None,
+        response_format: Optional[dict] = None,
+    ) -> None:
+        load_dotenv()
+        self.client = OpenAI() if OpenAI else None
+        self.model = model
+        self.instructions = instructions
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_output_tokens = max_output_tokens
+        self.seed = seed
+        self.response_format = response_format
+        self.logger = JsonlLogger()
+
+    def pred(
+        self,
+        prompt: str,
+        session: str,
+        tags: List[str],
+        context: Optional[str] = None,
+        context_title: str = "Context",
+    ):
+        """Send a prompt to the model and log the interaction."""
+        if self.client is None:
+            raise RuntimeError("OpenAI client not available; install the openai package.")
+
+        input_text = ""
+        if context:
+            input_text += f"{context_title}\n{context}\n\n"
+        input_text += prompt
+
+        start = time.time()
+        resp = self.client.responses.create(
+            model=self.model,
+            input=input_text,
+            instructions=self.instructions,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            max_output_tokens=self.max_output_tokens,
+            seed=self.seed,
+            response_format=self.response_format,
+        )
+        duration = time.time() - start
+        output_text = getattr(resp, "output_text", "")
+
+        record = make_record(prompt, output_text, session, tags)
+        record.update({
+            "model": self.model,
+            "duration": duration,
+        })
+        self.logger.log(record)
+        return resp

--- a/tools/log_utils.py
+++ b/tools/log_utils.py
@@ -1,0 +1,28 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class JsonlLogger:
+    """Append JSON records to a newline-delimited log file."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = Path(path or os.getenv("LLM_LOG_FILE", "llm_interactions.jsonl")).expanduser()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(self, record: Dict[str, Any]) -> None:
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def make_record(prompt: str, response: str, session: str, tags: List[str]) -> Dict[str, Any]:
+    """Create a simple log record."""
+    return {
+        "ts": time.time(),
+        "session": session,
+        "tags": tags,
+        "prompt": prompt,
+        "response": response,
+    }


### PR DESCRIPTION
## Summary
- Add `main.py` CLI exposing model, sampling, logging and grep-as-context options
- Implement `tools` package with `LLM` wrapper, context grep utility, and JSONL logger
- Add `.gitignore` for Python caches

## Testing
- `python -m py_compile main.py tools/*.py`
- `python main.py --help`
- `python tools/context_tools.py --paths README.md --keywords LLM --max-tokens 50`


------
https://chatgpt.com/codex/tasks/task_e_689819410c348322a5487af7d2b2df44